### PR TITLE
Fixed bug where handle_info was not properly testing if it had collected...

### DIFF
--- a/src/ekc.erl
+++ b/src/ekc.erl
@@ -218,10 +218,10 @@ handle_info({tcp, _, Part},
 	       parts = 
 		   <<
 		     Size:32/signed, 
-		     _/binary
+		     Data/binary
 		   >> = Parts} = S) when byte_size(
 					   <<
-					     Parts/binary, 
+					     Data/binary, 
 					     Part/binary
 					   >>) >= Size ->
     <<


### PR DESCRIPTION
... enough data from packets against the expected size of the data.

The previous version was including the Size:32/signed (4) bytes when making the byte_size comparison when it should not have.
